### PR TITLE
Fix: refreshToken 갱신을 위해 로직 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "multer": "^2.0.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "zod": "^4.0.11"
+        "zod": "^4.0.10"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.9",

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,4 +1,4 @@
-import { RequestHandler, Response } from "express";
+import { Request, RequestHandler, Response } from "express";
 import prisma from "../lib/prisma";
 import bcrypt from "bcryptjs";
 import generateToken from "../utils/token";
@@ -66,6 +66,7 @@ export const login: RequestHandler = async (req, res) => {
       secure: process.env.NODE_ENV === "production", //개발중일때는 false
       sameSite: "lax",
       maxAge: 7 * 24 * 60 * 60 * 1000,
+      path:"/"
     });
 
     return res.json({ 
@@ -86,7 +87,7 @@ export const login: RequestHandler = async (req, res) => {
 export const refreshToken = async (req: UserRequest, res: Response) => {
   const token = req.cookies.refreshToken;
   if (!token) {
-    return res.status(401).json({ message: AUTH_ERROR.TOKEN_MISSING });
+    return res.status(204).send() //로그인 안한 상태임
   }
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
@@ -117,3 +118,14 @@ export const refreshToken = async (req: UserRequest, res: Response) => {
     return res.status(500).json({ message: COMMON_ERROR.SERVER_ERROR });
   }
 };
+
+export const logout = (req: Request, res:Response) =>{
+  res.clearCookie("refreshToken", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/", 
+  });
+
+  return res.status(200).json({ message: "로그아웃 완료" });
+}

--- a/src/routes/authRouter.ts
+++ b/src/routes/authRouter.ts
@@ -1,10 +1,16 @@
 import { Router } from "express";
-import { login, refreshToken, signup } from "../controllers/authController";
+import {
+  login,
+  logout,
+  refreshToken,
+  signup,
+} from "../controllers/authController";
 
 const Authrouter = Router();
 
 Authrouter.post("/signup", signup);
 Authrouter.post("/login", login);
-Authrouter.post("/tokens", refreshToken);
+Authrouter.post("/refresh", refreshToken);
+Authrouter.post("/logout", logout);
 
 export default Authrouter;


### PR DESCRIPTION
## 🔍 어떤 작업인가요?

- refreshToken 갱신 로직 수정
- logout api 구현

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 로그/주석/디버깅 코드가 없나요?
- [ ] 변경된 사항을 문서화했나요? (해당 시)
- [X] 로컬에서 정상 동작 확인했나요?
- [ ] 리뷰어가 알아야 할 내용을 PR 설명에 충분히 적었나요?

---

## 📝 변경사항 요약

- refreshToken 갱신 시 초기 접속 또는 로그인하지 않았을 때 (토큰 없을때) 에러없이 처리하도록 수정
- cookie에 refreshToken을 저장하기 때문에 logout api가 필요하여 구현했습니다


---


