### PR TITLE
product router 엔드포인트 수정 / 토큰 검증 로직 수정

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ app.use("/api/products/:id/reviews", productReviewRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/users", userRouter);
 app.use("/api/brand", brandRouter);
-app.use("/api/product", ProductRouter);
+app.use("/api/products", ProductRouter);
 app.use("/api/cart", cartRouter);
 app.use("/api/wishlist", wishlistRouter);
 app.use("/api/coupon", CouponRouter);

--- a/src/controllers/couponController.ts
+++ b/src/controllers/couponController.ts
@@ -56,6 +56,9 @@ export const findMyCoupon = async (req: UserRequest, res: Response) => {
   try {
     const userCoupon = await prisma.userCoupon.findMany({
       where: { userId },
+      include:{
+        coupon: true
+      }
     });
     console.log(userCoupon);
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -9,7 +9,7 @@ export const authenticateJWT = (
 ) => {
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith("Bearer "))
-    return res.sendStatus(401).json({ message: "토큰이 없습니다." });
+    return res.status(401).json({ message: "토큰이 없습니다." });
 
   const token = authHeader.split(" ")[1];
 
@@ -19,9 +19,12 @@ export const authenticateJWT = (
   }
 
   jwt.verify(token, process.env.JWT_SECRET as string, (err, user) => {
-    if (err)
-      // return res.sendStatus(403).json({ message: "유효하지 않은 토큰입니다." });
+    if (err) {
+      if (err.name === "TokenExpiredError") {
+        return res.status(401).json({ message: "토큰 만료" });
+      }
       return res.status(403).json({ message: "유효하지 않은 토큰입니다." });
+    }
     req.user = user as UserRequest["user"];
     next();
   });

--- a/src/routes/couponRouter.ts
+++ b/src/routes/couponRouter.ts
@@ -9,7 +9,7 @@ import { authenticateJWT } from "../middleware/auth";
 
 const CouponRouter = Router();
 CouponRouter.post("/me/coupon", authenticateJWT, createCoupon)
-  .get("/me/coupon", authenticateJWT, findMyCoupon)
+  .get("/me", authenticateJWT, findMyCoupon)
   .get("/", findAllCoupons)
   .patch("/me/:id", authenticateJWT, useCoupon);
 


### PR DESCRIPTION
## 🔍 어떤 작업인가요?

- product router 엔드포인트 : product => products로 수정
- 프론트에서 axios 인터셉터를 위해 토큰 검증 시 401에러로 로직 수정

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 로그/주석/디버깅 코드가 없나요?
- [ ] 변경된 사항을 문서화했나요? (해당 시)
- [x] 로컬에서 정상 동작 확인했나요?
- [x] 리뷰어가 알아야 할 내용을 PR 설명에 충분히 적었나요?

---

## 📝 변경사항 요약

- 토큰 만료 시간 1분으로 설정하여 인터셉터 작동 여부 확인

---

## 📸 스크린샷 (선택)

- 토큰 만료 (1분 설정으로 테스트) 후 요청 실패 후 토큰 재발급

<img width="735" height="545" alt="스크린샷 2025-08-03 201031" src="https://github.com/user-attachments/assets/16a96130-3b9a-4c51-8d09-d74f9f808083" />


---

## 🔗 관련 이슈

- Closes #이슈번호
- 관련: #다른이슈

---

## 💬 기타 코멘트

- 쿠폰 정보 보내줄 때 쿠폰 이름과 할인 정보 필요하여 수정했습니다!
