### PR TITLE
Fix: 주문 목록 조회 시 아이템(리뷰포함) 정보 함께 내려주기

### DIFF
--- a/prisma/migrations/20250804112714_add_orderitem_to_review/migration.sql
+++ b/prisma/migrations/20250804112714_add_orderitem_to_review/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[orderItemId]` on the table `Review` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[productId,userId]` on the table `Review` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `orderItemId` to the `Review` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "orderItemId" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Review_orderItemId_key" ON "Review"("orderItemId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Review_productId_userId_key" ON "Review"("productId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Review" ADD CONSTRAINT "Review_orderItemId_fkey" FOREIGN KEY ("orderItemId") REFERENCES "OrderItem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,8 @@ model OrderItem {
   order             Order    @relation(fields: [orderId], references: [id])
   product           Product  @relation(fields: [productId], references: [id])
 
+  review            Review?  // 1:1 관계 (nullable, 아직 리뷰 안 썼을 수 있으니까)
+
 }
 
 // 사용자별 쿠폰 모델
@@ -167,18 +169,21 @@ model UserCoupon {
 
 // 리뷰 모델
 model Review {
-  id         Int         @id @default(autoincrement())
-  productId  Int
-  userId     Int
-  rating     Int
-  reviewText String      @db.Text
-  imageUrl   String?     @db.VarChar(255)
-  likesCount Int         @default(0)
-  createdAt  DateTime    @default(now())
-  updatedAt  DateTime    @updatedAt
-  product    Product     @relation(fields: [productId], references: [id])
-  user       User        @relation(fields: [userId], references: [id])
-  reviewTags ReviewTag[]
+  id           Int         @id @default(autoincrement())
+  orderItemId  Int         @unique // 주문 상품당 리뷰 1개만 가능하게
+  productId    Int
+  userId       Int
+  rating       Int
+  reviewText   String      @db.Text
+  imageUrl     String?     @db.VarChar(255)
+  likesCount   Int         @default(0)
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
+  product      Product     @relation(fields: [productId], references: [id])
+  user         User        @relation(fields: [userId], references: [id])
+  orderItem    OrderItem   @relation(fields: [orderItemId], references: [id])
+  reviewTags   ReviewTag[]
+  @@unique([productId, userId]) // 한 유저가 같은 상품에 여러 번 리뷰 작성 방지
 }
 
 // 리뷰 태그 모델

--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -89,6 +89,7 @@ export const getAllOrders = async (req: UserRequest, res: Response) => {
                 brand: true,
               },
             },
+            review: true
           },
         },
       },

--- a/src/controllers/productReviewController.ts
+++ b/src/controllers/productReviewController.ts
@@ -50,7 +50,7 @@ export const createProductReview = async (req: UserRequest, res: Response) => {
   }
 
   const productId = Number(req.params.id);
-  const { rating, reviewText } = req.body;
+  const { rating, reviewText,orderItemId } = req.body;
   let imageUrl: string | null = null;
   if (req.file) {
     imageUrl = `${req.protocol}://${req.get("host")}/uploads/${
@@ -62,6 +62,7 @@ export const createProductReview = async (req: UserRequest, res: Response) => {
       data: {
         rating: Number(rating),
         reviewText,
+        orderItemId,
         productId,
         userId,
         imageUrl,


### PR DESCRIPTION
## 🔍 어떤 작업인가요?

-내 주문 리뷰 작성을 위해 리뷰 테이블과 오더아이템 테이블 연결

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 로그/주석/디버깅 코드가 없나요?
- [ ] 변경된 사항을 문서화했나요? (해당 시)
- [x] 로컬에서 정상 동작 확인했나요?
- [x] 리뷰어가 알아야 할 내용을 PR 설명에 충분히 적었나요?

---

## 📝 변경사항 요약

- 주문 목록 조회 시 리뷰 정보도 함께 전달하도록 로직 수정


---

## 📸 스크린샷 (선택)

<img width="482" height="838" alt="스크린샷 2025-08-04 205233" src="https://github.com/user-attachments/assets/1cdedbfd-660f-435e-839e-174bcfe0b12d" />


---

## 💬 기타 코멘트

- 모델 수정했습니다. `npx migrate dev` 부탁드립니다!
