### PR TITLE
Fix: refreshToken은 갱신 취소로 만료시간 후 만료되도록 설정

### DIFF
--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,7 +1,7 @@
 import { User } from "../types/userType";
 import jwt from "jsonwebtoken";
 
-const generateToken = (user: User) => {
+export const generateAccessToken = (user: User) => {
   const accessToken = jwt.sign(
     {
       id: user.id,
@@ -13,6 +13,10 @@ const generateToken = (user: User) => {
     }
   );
 
+  return accessToken;
+};
+
+export const generateRefreshToken = (user: User) => {
   const refreshToken = jwt.sign(
     {
       id: user.id,
@@ -22,7 +26,6 @@ const generateToken = (user: User) => {
       expiresIn: "7d",
     }
   );
-  return { accessToken, refreshToken };
-};
 
-export default generateToken;
+  return refreshToken
+};


### PR DESCRIPTION
## 🔍 어떤 작업인가요?

- 리프레시토큰 갱신 취소 (액세스토큰만 갱신)

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 로그/주석/디버깅 코드가 없나요?
- [ ] 변경된 사항을 문서화했나요? (해당 시)
- [x] 로컬에서 정상 동작 확인했나요?
- [x] 리뷰어가 알아야 할 내용을 PR 설명에 충분히 적었나요?

---

## 📝 변경사항 요약

- 기존 방식은 리프레시도 함께 갱신되어 무한 로그인 상태를 유지했는데, 최초 1번만 발급하도록 수정


---


## 💬 기타 코멘트

- 
